### PR TITLE
Bug fix: timeLeft variable in eventRoutes

### DIFF
--- a/api/routes/eventRoutes.js
+++ b/api/routes/eventRoutes.js
@@ -107,7 +107,7 @@ router.post("/", async (req, res) => {
             console.log(user);
             if (user.timerEnd) {
             const sender = reqBody.event.user;
-            const timeLeft = (user.timerEnd - user.timerStart) / 60;
+            const timeLeft = Math.floor(((Date.now() / 1000) - user.timerStart) / 60);
             const whichTimer = user.timerName;
             console.log(`User ${userId} has reached Eph message statement`);
             postEphMessage({


### PR DESCRIPTION
# Description

This change fixes the issue of Focus Timer telling users who @mention someone in Focus Time the original time length of the timer instead of the time remaining.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
